### PR TITLE
feat(core): return single QualityWarning from get_warnings

### DIFF
--- a/src/ydata_quality/core/data_quality.py
+++ b/src/ydata_quality/core/data_quality.py
@@ -107,6 +107,7 @@ class DataQuality:
         filtered = [w for w in self._warnings if w.category == category] if category else self._warnings
         filtered = [w for w in filtered if w.test == test] if test else filtered
         filtered = [w for w in filtered if w.priority == Priority(priority)] if priority else filtered
+        filtered = filtered[0] if len(filtered)==1 else filtered # return single
         return filtered
 
     @property

--- a/src/ydata_quality/core/engine.py
+++ b/src/ydata_quality/core/engine.py
@@ -96,6 +96,7 @@ broad dtype list: {}.".format(supported_dtypes)
         filtered = [w for w in self._warnings if w.category == category] if category else self._warnings
         filtered = [w for w in filtered if w.test == test] if test else filtered
         filtered = [w for w in filtered if w.priority == Priority(priority)] if priority else filtered
+        filtered = filtered[0] if len(filtered)==1 else filtered # return single
         return filtered  # sort by priority
 
     @property


### PR DESCRIPTION
Whenever `get_warnings` finds a singular QualityWarning, return it individually instead of within a list.

The `get_warnings` method of DataQuality and QualityEngine are returning a list of QualityWarning's which can be filtered for some conditions. When we filter by test, a given warning will be (most likely) the sole warning for that specific test, thus retrieving it in a list does not make sense.