### PR TITLE
fix(datarelations): drop_nan before VIF computation

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ pytest
 sphinx
 myst-parser
 twine
+pytest
+nbconvert

--- a/src/ydata_quality/data_relations/engine.py
+++ b/src/ydata_quality/data_relations/engine.py
@@ -80,13 +80,13 @@ class DataRelationsDetector(QualityEngine):
             summary (bool): Print a report containing all the warnings detected during the data quality analysis.
         """
         results = {}
-        nan_or_const = df.nunique()<2  # Constant columns or all nan columns
+        nan_or_const = df.nunique() < 2  # Constant columns or all nan columns
         label = None if label in nan_or_const else label
-        self._logger.warning(f'The columns {list(nan_or_const.index[nan_or_const])} are constant or all NaNs and \
-were dropped from this evaluation.')
-        df = df.drop(columns = nan_or_const.index[nan_or_const])  # Constant columns or all nan columns are dropped
+        self._logger.warning('The columns %s are constant or all NaNs and \
+were dropped from this evaluation.', list(nan_or_const.index[nan_or_const]))
+        df = df.drop(columns=nan_or_const.index[nan_or_const])  # Constant columns or all nan columns are dropped
         if df.shape[1] < 2:
-            self._logger.warning(f'There are fewer than 2 columns on the dataset where correlations can be computed. \
+            self._logger.warning('There are fewer than 2 columns on the dataset where correlations can be computed. \
 Skipping the DataRelations engine execution.')
             return results
         self.dtypes = (df, dtypes)  # Consider refactoring QualityEngine dtypes (df as argument of setter)
@@ -107,8 +107,8 @@ Skipped potential confounder and collider detection tests.')
         if label:
             try:
                 results['Feature Importance'] = self._feature_importance(corr_mat, p_corr_mat, label, corr_th)
-            except AssertionError as e:
-                self._logger.warning(str(e))
+            except AssertionError as exception:
+                self._logger.warning(str(exception))
         results['High Collinearity'] = self._high_collinearity_detection(df, self.dtypes, label, vif_th, p_th=p_th)
         self._clean_warnings()
         if summary:

--- a/src/ydata_quality/data_relations/engine.py
+++ b/src/ydata_quality/data_relations/engine.py
@@ -48,7 +48,7 @@ class DataRelationsDetector(QualityEngine):
         wrong_dtypes = [col for col, dtype in dtypes.items() if dtype not in supported_dtypes]
         if len(wrong_dtypes) > 0:
             self._logger.warning(
-                f"Columns {wrong_dtypes} of dtypes where not defined with a supported dtype and will be inferred.")
+                "Columns %s have no valid dtypes. Supported dtypes will be inferred.", wrong_dtypes)
         dtypes = {key: val for key, val in dtypes.items() if key not in cols_not_in_df + wrong_dtypes}
         df_col_set = set(df.columns)
         dtypes_col_set = set(dtypes.keys())

--- a/src/ydata_quality/utils/auxiliary.py
+++ b/src/ydata_quality/utils/auxiliary.py
@@ -92,9 +92,10 @@ def find_duplicate_columns(df: DataFrame, is_close=False) -> dict:
     return dups
 
 
-def drop_column_list(df: DataFrame, column_list: dict):
+def drop_column_list(df: DataFrame, column_list: dict, label: str = None):
     "Drops from a DataFrame a duplicates mapping of columns to duplicate lists. Works inplace."
     for col, dup_list in column_list.items():
+        dup_list = [col for col in dup_list if col != label]
         if col in df.columns:  # Ensures we will not drop both members of duplicate pairs
             df.drop(columns=dup_list, index=dup_list, inplace=True)
 

--- a/src/ydata_quality/utils/correlations.py
+++ b/src/ydata_quality/utils/correlations.py
@@ -195,6 +195,7 @@ def vif_collinearity(data: DataFrame, dtypes: dict, label: str = None) -> Series
     if label and label in data.columns:
         data = data.drop(columns=label)
     num_columns = [col for col in data.columns if dtypes[col] == 'numerical']
+    data = data.dropna(subset=num_columns)
     warnings.filterwarnings("ignore", category=RuntimeWarning)
     vifs = [vif(data[num_columns].values, i) for i in range(len(data[num_columns].columns))]
     warnings.resetwarnings()

--- a/src/ydata_quality/utils/correlations.py
+++ b/src/ydata_quality/utils/correlations.py
@@ -201,7 +201,10 @@ def vif_collinearity(data: DataFrame, dtypes: dict, label: str = None) -> Series
     num_columns = [col for col in data.columns if dtypes[col] == 'numerical']
     data = data.dropna(subset=num_columns)
     warnings.filterwarnings("ignore", category=RuntimeWarning)
-    vifs = {} if data.empty else {num_columns[i]: vif(data[num_columns].values, i) for i in range(len(data[num_columns].columns))}
+    if data.empty:
+        vifs = {}
+    else:
+        vifs = {num_columns[i]: vif(data[num_columns].values, i) for i in range(len(data[num_columns].columns))}
     warnings.resetwarnings()
     return Series(data=vifs, dtype=float).sort_values(ascending=False)
 

--- a/tests/engines/test_data_relations.py
+++ b/tests/engines/test_data_relations.py
@@ -1,0 +1,65 @@
+"Tests for the DataRelations module."
+from pytest import fixture
+from pandas import read_csv
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+
+from ydata_quality.data_relations.engine import DataRelationsDetector
+
+
+@fixture
+def data_relations():
+    return DataRelationsDetector()
+
+@fixture
+def example_dataset_transformed():
+    dataset_path = 'datasets/transformed/census_10k.csv'
+    return read_csv(dataset_path)
+
+@fixture
+def ipynb_tutorial():
+    path = "tutorials/data_relations.ipynb"
+    with open(path) as f:
+        nb = nbformat.read(f, as_version=4)
+    return nb
+
+@fixture
+def dr_results_no_pcorr(data_relations, example_dataset_transformed):
+    results = data_relations.evaluate(
+                                      df = example_dataset_transformed,
+                                      dtypes = None,
+                                      label = 'income',
+                                      plot = False)
+    return data_relations, results
+
+@fixture
+def dr_results_pc_corr(data_relations, example_dataset_transformed):
+    df = example_dataset_transformed.drop(columns=['education-num'])
+    results = data_relations.evaluate(
+                                      df = df,
+                                      dtypes = None,
+                                      label = 'income',
+                                      plot = False)
+    return data_relations, results
+
+def test_get_warnings(dr_results_no_pcorr):
+    new_drd = DataRelationsDetector()
+    assert isinstance(new_drd.get_warnings(), list)
+    assert len(new_drd.get_warnings()) == 0
+
+    ran_data_relations, _ = dr_results_no_pcorr
+    assert isinstance(ran_data_relations.get_warnings(), list)
+    assert len(ran_data_relations.get_warnings()) > 0
+
+def test_results(dr_results_no_pcorr, dr_results_pc_corr):
+    _, results = dr_results_no_pcorr
+    assert isinstance(results, dict)
+    assert set(results.keys()) == set(['Correlations', 'Feature Importance', 'High Collinearity'])
+
+    _, results2 = dr_results_pc_corr
+    assert isinstance(results2, dict)
+    assert set(results2.keys()) == set(['Correlations', 'Confounders', 'Colliders', 'Feature Importance', 'High Collinearity'])
+
+def test_tutorial_notebook_execution(ipynb_tutorial):
+    ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+    assert ep.preprocess(ipynb_tutorial, {'metadata': {'path': "tutorials"}})

--- a/tests/engines/test_data_relations.py
+++ b/tests/engines/test_data_relations.py
@@ -18,11 +18,10 @@ def fixture_example_dataset_transformed():
     return read_csv(dataset_path)
 
 
-# pylint: disable=unspecified-encoding
 @fixture(name='ipynb_tutorial')
 def fixture_ipynb_tutorial():
     path = "tutorials/data_relations.ipynb"
-    with open(path) as file:
+    with open(path, encoding='utf8', errors='strict') as file:
         ntb = nbformat.read(file, as_version=4)
     return ntb
 

--- a/tests/engines/test_data_relations.py
+++ b/tests/engines/test_data_relations.py
@@ -7,40 +7,47 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from ydata_quality.data_relations.engine import DataRelationsDetector
 
 
+# pylint: disable=redefined-outer-name
+
+
 @fixture
 def data_relations():
     return DataRelationsDetector()
+
 
 @fixture
 def example_dataset_transformed():
     dataset_path = 'datasets/transformed/census_10k.csv'
     return read_csv(dataset_path)
 
+
+# pylint: disable=unspecified-encoding
 @fixture
 def ipynb_tutorial():
     path = "tutorials/data_relations.ipynb"
-    with open(path) as f:
-        nb = nbformat.read(f, as_version=4)
-    return nb
+    with open(path) as file:
+        ntb = nbformat.read(file, as_version=4)
+    return ntb
+
 
 @fixture
 def dr_results_no_pcorr(data_relations, example_dataset_transformed):
-    results = data_relations.evaluate(
-                                      df = example_dataset_transformed,
-                                      dtypes = None,
-                                      label = 'income',
-                                      plot = False)
+    results = data_relations.evaluate(df=example_dataset_transformed,
+                                      dtypes=None,
+                                      label='income',
+                                      plot=False)
     return data_relations, results
+
 
 @fixture
 def dr_results_pc_corr(data_relations, example_dataset_transformed):
     df = example_dataset_transformed.drop(columns=['education-num'])
-    results = data_relations.evaluate(
-                                      df = df,
-                                      dtypes = None,
-                                      label = 'income',
-                                      plot = False)
+    results = data_relations.evaluate(df=df,
+                                      dtypes=None,
+                                      label='income',
+                                      plot=False)
     return data_relations, results
+
 
 def test_get_warnings(dr_results_no_pcorr):
     new_drd = DataRelationsDetector()
@@ -51,6 +58,7 @@ def test_get_warnings(dr_results_no_pcorr):
     assert isinstance(ran_data_relations.get_warnings(), list)
     assert len(ran_data_relations.get_warnings()) > 0
 
+
 def test_results(dr_results_no_pcorr, dr_results_pc_corr):
     _, results = dr_results_no_pcorr
     assert isinstance(results, dict)
@@ -58,8 +66,10 @@ def test_results(dr_results_no_pcorr, dr_results_pc_corr):
 
     _, results2 = dr_results_pc_corr
     assert isinstance(results2, dict)
-    assert set(results2.keys()) == set(['Correlations', 'Confounders', 'Colliders', 'Feature Importance', 'High Collinearity'])
+    assert set(results2.keys()) == set(['Correlations', 'Confounders', 'Colliders',
+                                        'Feature Importance', 'High Collinearity'])
+
 
 def test_tutorial_notebook_execution(ipynb_tutorial):
-    ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
-    assert ep.preprocess(ipynb_tutorial, {'metadata': {'path': "tutorials"}})
+    exp = ExecutePreprocessor(timeout=600, kernel_name='python3')
+    assert exp.preprocess(ipynb_tutorial, {'metadata': {'path': "tutorials"}})

--- a/tests/engines/test_data_relations.py
+++ b/tests/engines/test_data_relations.py
@@ -7,31 +7,28 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from ydata_quality.data_relations.engine import DataRelationsDetector
 
 
-# pylint: disable=redefined-outer-name
-
-
-@fixture
-def data_relations():
+@fixture(name='data_relations')
+def fixture_data_relations():
     return DataRelationsDetector()
 
 
-@fixture
-def example_dataset_transformed():
+@fixture(name='example_dataset_transformed')
+def fixture_example_dataset_transformed():
     dataset_path = 'datasets/transformed/census_10k.csv'
     return read_csv(dataset_path)
 
 
 # pylint: disable=unspecified-encoding
-@fixture
-def ipynb_tutorial():
+@fixture(name='ipynb_tutorial')
+def fixture_ipynb_tutorial():
     path = "tutorials/data_relations.ipynb"
     with open(path) as file:
         ntb = nbformat.read(file, as_version=4)
     return ntb
 
 
-@fixture
-def dr_results_no_pcorr(data_relations, example_dataset_transformed):
+@fixture(name='dr_results_no_pcorr')
+def fixture_dr_results_no_pcorr(data_relations, example_dataset_transformed):
     results = data_relations.evaluate(df=example_dataset_transformed,
                                       dtypes=None,
                                       label='income',
@@ -39,8 +36,8 @@ def dr_results_no_pcorr(data_relations, example_dataset_transformed):
     return data_relations, results
 
 
-@fixture
-def dr_results_pc_corr(data_relations, example_dataset_transformed):
+@fixture(name='dr_results_pc_corr')
+def fixture_dr_results_pc_corr(data_relations, example_dataset_transformed):
     df = example_dataset_transformed.drop(columns=['education-num'])
     results = data_relations.evaluate(df=df,
                                       dtypes=None,


### PR DESCRIPTION
Closes #58.

A series of exceptions that broke and could break the execution were fixed by:

- dropping constant or NaN columns before computations
- skipping entire DataRelations execution in case the remaining dataset has less than 2 columns